### PR TITLE
fix sarama failing error

### DIFF
--- a/out/kafkamdam/kafkamdam.go
+++ b/out/kafkamdam/kafkamdam.go
@@ -24,6 +24,7 @@ func New(topic string, brokers []string, codec string, stats met.Backend) (*Kafk
 	// Because we don't change the flush settings, sarama will try to produce messages
 	// as fast as possible to keep latency low.
 	config := sarama.NewConfig()
+	config.Producer.Return.Successes = true
 	config.Producer.RequiredAcks = sarama.WaitForAll // Wait for all in-sync replicas to ack the message
 	config.Producer.Retry.Max = 10                   // Retry up to 10 times to produce the message
 	config.Producer.Compression = out.GetCompression(codec)

--- a/out/kafkamdm/kafkamdm.go
+++ b/out/kafkamdm/kafkamdm.go
@@ -28,6 +28,7 @@ func New(topic string, brokers []string, codec string, stats met.Backend, shardO
 	// Because we don't change the flush settings, sarama will try to produce messages
 	// as fast as possible to keep latency low.
 	config := sarama.NewConfig()
+	config.Producer.Return.Successes = true
 	config.Producer.RequiredAcks = sarama.WaitForAll // Wait for all in-sync replicas to ack the message
 	config.Producer.Retry.Max = 10                   // Retry up to 10 times to produce the message
 	config.Producer.Compression = out.GetCompression(codec)


### PR DESCRIPTION
Seems they changed upstream. 
```
./fakemetrics -keys-per-org 100 -orgs 1 -statsd-addr statsdaemon:8125 -kafka-mdam-tcp-address kafka:9092 -offset 1y -speedup 40000 -log-level 0
2017/05/01 20:00:02 [fakemetrics.go:122 main()] [E] failed to create kafka-mdam output. kafka: invalid configuration (Producer.Return.Successes must be true to be used in a SyncProducer)
```

Tested my update with the following setting:

```
 ./fakemetrics -keys-per-org 100 -orgs 1 -statsd-addr statsdaemon:8125 -kafka-mdm-tcp-address kafka:9092 -offset 1y -speedup 40000 -log-level 0
each 100ms, sending 400000 metrics. (sending the 100 metrics 4000 times per flush, each time advancing them by 1 s)
2017/05/01 20:00:31 [I] starting listener on :6764
```