### PR TITLE
bring in sync with metrictank

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Available Commands:
   agents           Mimic independent agents
   agginput         A particular workload good to test performance of carbon-relay-ng aggregators
   backfill         backfills old data and stops when 'now' is reached
+  bad              Sends out invalid/out-of-order/duplicate metric data
   feed             Publishes a realtime feed of data
   help             Help about any command
   resolutionchange Sends out metric with changing intervals, time range 24hours
@@ -27,10 +28,10 @@ Available Commands:
   version          Print the version number
 
 Flags:
-  -t, --add-tags                     add tags to generated metrics (default false)
+  -t, --add-tags                     add the built-in tags to generated metrics (default false)
       --carbon-addr string           carbon TCP address. e.g. localhost:2003
       --config string                config file (default is $HOME/.fakemetrics.yaml)
-      --custom-tags strings          A list of comma separated tags (i.e. "tag1=value1,tag2=value2")(default empty)
+      --custom-tags strings          A list of comma separated tags (i.e. "tag1=value1,tag2=value2")(default empty) conflicts with add-tags
       --gnet-addr string             gnet address. e.g. http://localhost:8081
       --gnet-key string              gnet api key
   -h, --help                         help for fakemetrics
@@ -42,8 +43,8 @@ Flags:
       --listen string                http listener address for pprof. (default ":6764")
       --log-level int                log level. 0=TRACE|1=DEBUG|2=INFO|3=WARN|4=ERROR|5=CRITICAL|6=FATAL (default 2)
       --num-unique-custom-tags int   a number between 0 and the length of custom-tags. when using custom-tags this will make the tags unique (default 0)
-      --num-unique-tags int          a number between 0 and 10. when using add-tags this will make the tags unique (default 0)
-      --partition-scheme string      method used for partitioning metrics (kafka-mdm-only). (byOrg|bySeries|lastNum) (default "bySeries")
+      --num-unique-tags int          a number between 0 and 10. when using add-tags this will add a unique number to some built-in tags (default 1)
+      --partition-scheme string      method used for partitioning metrics (kafka-mdm-only). (byOrg|bySeries|bySeriesWithTags|bySeriesWithTagsFnv|lastNum) (default "bySeries")
       --statsd-addr string           statsd TCP address. e.g. 'localhost:8125'
       --statsd-type string           statsd type: standard or datadog (default "standard")
       --stdout                       enable emitting metrics to stdout

--- a/cmd/agents.go
+++ b/cmd/agents.go
@@ -22,8 +22,8 @@ import (
 
 	"time"
 
+	"github.com/grafana/metrictank/schema"
 	"github.com/raintank/worldping-api/pkg/log"
-	"github.com/raintank/schema"
 )
 
 var agentsCmd = &cobra.Command{

--- a/cmd/bad.go
+++ b/cmd/bad.go
@@ -17,8 +17,8 @@ package cmd
 import (
 	"time"
 
+	"github.com/grafana/metrictank/schema"
 	"github.com/raintank/fakemetrics/out"
-	"github.com/raintank/schema"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )

--- a/cmd/datafeed.go
+++ b/cmd/datafeed.go
@@ -6,8 +6,8 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/grafana/metrictank/schema"
 	"github.com/raintank/fakemetrics/out"
-	"github.com/raintank/schema"
 	"github.com/raintank/worldping-api/pkg/log"
 )
 

--- a/cmd/resolutionchange.go
+++ b/cmd/resolutionchange.go
@@ -19,10 +19,10 @@ import (
 
 	"time"
 
+	"github.com/grafana/metrictank/schema"
 	"github.com/raintank/fakemetrics/out"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"github.com/raintank/schema"
 )
 
 // resolutionchangeCmd represents the resolutionchange command

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -104,7 +104,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&statsdType, "statsd-type", "standard", "statsd type: standard or datadog")
 
 	rootCmd.PersistentFlags().BoolVarP(&addTags, "add-tags", "t", false, "add the built-in tags to generated metrics (default false)")
-	rootCmd.PersistentFlags().IntVar(&numUniqueTags, "num-unique-tags", 1, "a number between 0 and 10. when using add-tags this will add a unique number to some built-in tags (default 1)")
+	rootCmd.PersistentFlags().IntVar(&numUniqueTags, "num-unique-tags", 1, "a number between 0 and 10. when using add-tags this will add a unique number to some built-in tags")
 	rootCmd.PersistentFlags().StringSliceVar(&customTags, "custom-tags", []string{}, "A list of comma separated tags (i.e. \"tag1=value1,tag2=value2\")(default empty) conflicts with add-tags")
 	rootCmd.PersistentFlags().IntVar(&numUniqueCustomTags, "num-unique-custom-tags", 0, "a number between 0 and the length of custom-tags. when using custom-tags this will make the tags unique (default 0)")
 
@@ -113,7 +113,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&kafkaMdmV2, "kafka-mdm-v2", true, "enable MetricPoint optimization (send MetricData first, then optimized MetricPoint payloads)")
 	rootCmd.PersistentFlags().StringVar(&kafkaMdamAddr, "kafka-mdam-addr", "", "kafka TCP address for MetricDataArray-Msgp messages. e.g. localhost:9092")
 	rootCmd.PersistentFlags().StringVar(&kafkaCompression, "kafka-comp", "snappy", "compression: none|gzip|snappy")
-	rootCmd.PersistentFlags().StringVar(&partitionScheme, "partition-scheme", "bySeries", "method used for partitioning metrics (kafka-mdm-only). (byOrg|bySeries|lastNum)")
+	rootCmd.PersistentFlags().StringVar(&partitionScheme, "partition-scheme", "bySeries", "method used for partitioning metrics (kafka-mdm-only). (byOrg|bySeries|bySeriesWithTags|bySeriesWithTagsFnv|lastNum)")
 	rootCmd.PersistentFlags().StringVar(&carbonAddr, "carbon-addr", "", "carbon TCP address. e.g. localhost:2003")
 	rootCmd.PersistentFlags().StringVar(&gnetAddr, "gnet-addr", "", "gnet address. e.g. http://localhost:8081")
 	rootCmd.PersistentFlags().StringVar(&gnetKey, "gnet-key", "", "gnet api key")

--- a/cmd/storageconf.go
+++ b/cmd/storageconf.go
@@ -19,10 +19,10 @@ import (
 
 	"time"
 
+	"github.com/grafana/metrictank/schema"
 	"github.com/raintank/fakemetrics/out"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"github.com/raintank/schema"
 )
 
 // storageconfCmd represents the storageconf command

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -15,6 +15,8 @@
 package cmd
 
 import (
+	"time"
+
 	"github.com/raintank/worldping-api/pkg/log"
 
 	"github.com/raintank/fakemetrics/out"
@@ -63,7 +65,7 @@ func getOutputs() []out.Out {
 		if kafkaMdmTopic == "" {
 			log.Fatal(4, "kafka-mdm needs the topic to be set")
 		}
-		o, err := kafkamdm.New(kafkaMdmTopic, []string{kafkaMdmAddr}, kafkaCompression, stats, partitionScheme, kafkaMdmV2)
+		o, err := kafkamdm.New(kafkaMdmTopic, []string{kafkaMdmAddr}, kafkaCompression, 30*time.Second, stats, partitionScheme, kafkaMdmV2)
 		if err != nil {
 			log.Fatal(4, "failed to create kafka-mdm output. %s", err)
 		}

--- a/out/carbon/carbon.go
+++ b/out/carbon/carbon.go
@@ -8,9 +8,9 @@ import (
 	"sync"
 	"time"
 
+	"github.com/grafana/metrictank/schema"
 	"github.com/raintank/fakemetrics/out"
 	"github.com/raintank/met"
-	"github.com/raintank/schema"
 )
 
 var errClosed = errors.New("output is closed")

--- a/out/gnet/gnet.go
+++ b/out/gnet/gnet.go
@@ -8,12 +8,12 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/grafana/metrictank/schema"
+	"github.com/grafana/metrictank/schema/msg"
 	"github.com/jpillora/backoff"
 	"github.com/raintank/fakemetrics/out"
 	"github.com/raintank/met"
 	"github.com/raintank/worldping-api/pkg/log"
-	"github.com/raintank/schema"
-	"github.com/raintank/schema/msg"
 )
 
 type Msg struct {

--- a/out/kafkamdam/kafkamdam.go
+++ b/out/kafkamdam/kafkamdam.go
@@ -4,10 +4,10 @@ import (
 	"time"
 
 	"github.com/Shopify/sarama"
+	"github.com/grafana/metrictank/schema"
+	"github.com/grafana/metrictank/schema/msg"
 	"github.com/raintank/fakemetrics/out"
 	"github.com/raintank/met"
-	"github.com/raintank/schema"
-	"github.com/raintank/schema/msg"
 )
 
 // kafka output that sends MetricDataArrayMsgp messages

--- a/out/kafkamdm/kafkamdm.go
+++ b/out/kafkamdm/kafkamdm.go
@@ -170,7 +170,7 @@ func (k *KafkaMdm) Flush(metrics []*schema.MetricData) error {
 
 	}
 	if notOk > 0 {
-		fmt.Println(preFlush, notOk, "metrics could not be sent as v2 MetricPoint")
+		log.Info(notOk, "metrics could not be sent as v2 MetricPoint")
 	}
 	prePub := time.Now()
 	err := k.client.SendMessages(payload)

--- a/out/kafkamdm/kafkamdm.go
+++ b/out/kafkamdm/kafkamdm.go
@@ -88,7 +88,7 @@ func New(topic string, brokers []string, codec string, timeout time.Duration, st
 	} else {
 		part, err = p.NewKafka(partitionScheme)
 		if err != nil {
-			return nil, fmt.Errorf("partitionScheme must be one of 'byOrg|bySeries|bySeriesWithTags|lastNum'. got %s", partitionScheme)
+			return nil, fmt.Errorf("partitionscheme must be one of 'byOrg|bySeries|bySeriesWithTags|bySeriesWithTagsFnv|lastNum'. got %s", partitionScheme)
 		}
 	}
 

--- a/out/kafkamdm/kafkamdm.go
+++ b/out/kafkamdm/kafkamdm.go
@@ -10,11 +10,11 @@ import (
 
 	"github.com/Shopify/sarama"
 	p "github.com/grafana/metrictank/cluster/partitioner"
+	"github.com/grafana/metrictank/schema"
+	"github.com/grafana/metrictank/schema/msg"
 	"github.com/raintank/fakemetrics/out"
 	"github.com/raintank/fakemetrics/out/kafkamdm/keycache"
 	"github.com/raintank/met"
-	"github.com/raintank/schema"
-	"github.com/raintank/schema/msg"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/out/kafkamdm/kafkamdm.go
+++ b/out/kafkamdm/kafkamdm.go
@@ -39,10 +39,10 @@ type LastNumPartitioner struct{}
 func (p *LastNumPartitioner) Partition(m schema.PartitionedMetric, numPartitions int32) (int32, error) {
 	name := m.KeyBySeries(nil)
 	index := bytes.LastIndexByte(name, '.')
-	if index < 0 {
+	if index < 0 || index == len(name)-1 {
 		return 0, fmt.Errorf("invalid metricname for LastNumPartitioner: '%s'", name)
 	}
-	part, err := strconv.ParseInt(string(name[index:]), 10, 32)
+	part, err := strconv.ParseInt(string(name[index+1:]), 10, 32)
 	if err != nil {
 		return 0, fmt.Errorf("invalid metricname for LastNumPartitioner: '%s'", name)
 	}

--- a/out/kafkamdm/kafkamdm.go
+++ b/out/kafkamdm/kafkamdm.go
@@ -54,7 +54,7 @@ func (p *LastNumPartitioner) GetPartitionKey(m schema.PartitionedMetric, b []byt
 	return m.KeyBySeries(b), nil
 }
 
-func New(topic string, brokers []string, codec string, stats met.Backend, partitionScheme string, v2 bool) (*KafkaMdm, error) {
+func New(topic string, brokers []string, codec string, timeout time.Duration, stats met.Backend, partitionScheme string, v2 bool) (*KafkaMdm, error) {
 	// We are looking for strong consistency semantics.
 	// Because we don't change the flush settings, sarama will try to produce messages
 	// as fast as possible to keep latency low.
@@ -63,6 +63,11 @@ func New(topic string, brokers []string, codec string, stats met.Backend, partit
 	config.Producer.RequiredAcks = sarama.WaitForAll // Wait for all in-sync replicas to ack the message
 	config.Producer.Retry.Max = 10                   // Retry up to 10 times to produce the message
 	config.Producer.Compression = out.GetCompression(codec)
+
+	config.Net.DialTimeout = timeout
+	config.Net.ReadTimeout = timeout
+	config.Net.WriteTimeout = timeout
+
 	err := config.Validate()
 	if err != nil {
 		return nil, err

--- a/out/kafkamdm/keycache/cache.go
+++ b/out/kafkamdm/keycache/cache.go
@@ -3,7 +3,7 @@ package keycache
 import (
 	"time"
 
-	"github.com/raintank/schema"
+	"github.com/grafana/metrictank/schema"
 )
 
 // Cache is a single-tenant keycache

--- a/out/kafkamdm/keycache/keycache.go
+++ b/out/kafkamdm/keycache/keycache.go
@@ -4,7 +4,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/raintank/schema"
+	"github.com/grafana/metrictank/schema"
 )
 
 // KeyCache tracks for all orgs, which keys have been seen, and when was the last time

--- a/out/kafkamdm/keycache/shard.go
+++ b/out/kafkamdm/keycache/shard.go
@@ -4,7 +4,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/raintank/schema"
+	"github.com/grafana/metrictank/schema"
 )
 
 // SubKey is the last 15 bytes of a 16 byte Key

--- a/out/kafkamdm/keycache/shard_test.go
+++ b/out/kafkamdm/keycache/shard_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/raintank/schema"
+	"github.com/grafana/metrictank/schema"
 )
 
 func GetKey(suffix int) schema.Key {

--- a/out/out.go
+++ b/out/out.go
@@ -3,8 +3,8 @@ package out
 import (
 	"fmt"
 
+	"github.com/grafana/metrictank/schema"
 	"github.com/raintank/met"
-	"github.com/raintank/schema"
 )
 
 // Out submits metricdata to a destination

--- a/out/stdout/stdout.go
+++ b/out/stdout/stdout.go
@@ -6,9 +6,9 @@ import (
 	"sync"
 	"time"
 
+	"github.com/grafana/metrictank/schema"
 	"github.com/raintank/fakemetrics/out"
 	"github.com/raintank/met"
-	"github.com/raintank/schema"
 )
 
 type Stdout struct {


### PR DESCRIPTION
pull in changes / best practices from the fakemetrics copy that lives in metrictank. in particular the new partitioning.
corresponding PR for metrictank: https://github.com/grafana/metrictank/pull/1536
These 2 PR's makes the 2 codebases identical again, such that they can be merged.

fix #18 